### PR TITLE
Feature/implement mail token for forgot password and email confirm

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/auth/application/repositories/MailRepository.java
+++ b/application/src/main/java/com/kaua/ecommerce/auth/application/repositories/MailRepository.java
@@ -1,0 +1,14 @@
+package com.kaua.ecommerce.auth.application.repositories;
+
+import com.kaua.ecommerce.auth.domain.mailtokens.MailToken;
+
+import java.util.List;
+
+public interface MailRepository {
+
+    MailToken save(MailToken mailToken);
+
+    List<MailToken> findByEmail(String email);
+
+    void deleteByToken(String token);
+}

--- a/application/src/main/java/com/kaua/ecommerce/auth/application/repositories/UserRepository.java
+++ b/application/src/main/java/com/kaua/ecommerce/auth/application/repositories/UserRepository.java
@@ -13,5 +13,7 @@ public interface UserRepository {
 
     Optional<User> findById(UUID id);
 
+    Optional<User> findByEmail(String email);
+
     boolean existsByEmail(String email);
 }

--- a/application/src/main/java/com/kaua/ecommerce/auth/application/usecases/users/CreateMailTokenUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/auth/application/usecases/users/CreateMailTokenUseCase.java
@@ -1,0 +1,9 @@
+package com.kaua.ecommerce.auth.application.usecases.users;
+
+import com.kaua.ecommerce.auth.application.UseCase;
+import com.kaua.ecommerce.auth.application.usecases.users.inputs.CreateMailTokenInput;
+import com.kaua.ecommerce.auth.application.usecases.users.outputs.CreateMailTokenOutput;
+
+public abstract class CreateMailTokenUseCase extends
+        UseCase<CreateMailTokenInput, CreateMailTokenOutput> {
+}

--- a/application/src/main/java/com/kaua/ecommerce/auth/application/usecases/users/impl/DefaultCreateMailTokenUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/auth/application/usecases/users/impl/DefaultCreateMailTokenUseCase.java
@@ -1,0 +1,65 @@
+package com.kaua.ecommerce.auth.application.usecases.users.impl;
+
+import com.kaua.ecommerce.auth.application.exceptions.UseCaseInputCannotBeNullException;
+import com.kaua.ecommerce.auth.application.repositories.MailRepository;
+import com.kaua.ecommerce.auth.application.repositories.UserRepository;
+import com.kaua.ecommerce.auth.application.usecases.users.CreateMailTokenUseCase;
+import com.kaua.ecommerce.auth.application.usecases.users.inputs.CreateMailTokenInput;
+import com.kaua.ecommerce.auth.application.usecases.users.outputs.CreateMailTokenOutput;
+import com.kaua.ecommerce.auth.domain.exceptions.UserIsDeletedException;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailToken;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailType;
+import com.kaua.ecommerce.auth.domain.users.User;
+import com.kaua.ecommerce.lib.domain.exceptions.DomainException;
+import com.kaua.ecommerce.lib.domain.exceptions.NotFoundException;
+import com.kaua.ecommerce.lib.domain.utils.IdentifierUtils;
+import com.kaua.ecommerce.lib.domain.utils.InstantUtils;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+public class DefaultCreateMailTokenUseCase extends CreateMailTokenUseCase {
+
+    private final MailRepository mailRepository;
+    private final UserRepository userRepository;
+
+    public DefaultCreateMailTokenUseCase(
+            final MailRepository mailRepository,
+            final UserRepository userRepository
+    ) {
+        this.mailRepository = Objects.requireNonNull(mailRepository);
+        this.userRepository = Objects.requireNonNull(userRepository);
+    }
+
+    @Override
+    public CreateMailTokenOutput execute(final CreateMailTokenInput input) {
+        if (input == null) throw new UseCaseInputCannotBeNullException(DefaultCreateMailTokenUseCase.class.getSimpleName());
+
+        final var aMailType = MailType.of(input.type())
+                .orElseThrow(() -> DomainException
+                        .with("Invalid mail type %s".formatted(input.type())));
+
+        final var aUser = this.userRepository.findByEmail(input.email())
+                .orElseThrow(NotFoundException.with(User.class, input.email()));
+
+        if (aUser.isDeleted()) {
+            throw new UserIsDeletedException(aUser.getId().value().toString());
+        }
+
+        final var aMailsTokens = this.mailRepository.findByEmail(input.email());
+
+        aMailsTokens.stream()
+                .filter(it -> it.getType().name().equals(aMailType.name()))
+                .forEach(it -> this.mailRepository.deleteByToken(it.getToken()));
+
+        final var aMailToken = MailToken.newMailToken(
+                aUser.getEmail().value(),
+                aUser.getId(),
+                IdentifierUtils.generateNewIdWithoutHyphen(),
+                aMailType,
+                InstantUtils.now().plus(3, ChronoUnit.DAYS)
+        );
+
+        return new CreateMailTokenOutput(this.mailRepository.save(aMailToken));
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/auth/application/usecases/users/inputs/CreateMailTokenInput.java
+++ b/application/src/main/java/com/kaua/ecommerce/auth/application/usecases/users/inputs/CreateMailTokenInput.java
@@ -1,0 +1,4 @@
+package com.kaua.ecommerce.auth.application.usecases.users.inputs;
+
+public record CreateMailTokenInput(String email, String type) {
+}

--- a/application/src/main/java/com/kaua/ecommerce/auth/application/usecases/users/outputs/CreateMailTokenOutput.java
+++ b/application/src/main/java/com/kaua/ecommerce/auth/application/usecases/users/outputs/CreateMailTokenOutput.java
@@ -1,0 +1,18 @@
+package com.kaua.ecommerce.auth.application.usecases.users.outputs;
+
+import com.kaua.ecommerce.auth.domain.mailtokens.MailToken;
+
+public record CreateMailTokenOutput(
+        String userId,
+        String mailId,
+        String type
+) {
+
+    public CreateMailTokenOutput(final MailToken aMailToken) {
+        this(
+                aMailToken.getUserId().value().toString(),
+                aMailToken.getId().value().toString(),
+                aMailToken.getType().name()
+        );
+    }
+}

--- a/application/src/test/java/com/kaua/ecommerce/auth/application/usecases/users/impl/CreateMailTokenUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/auth/application/usecases/users/impl/CreateMailTokenUseCaseTest.java
@@ -1,0 +1,228 @@
+package com.kaua.ecommerce.auth.application.usecases.users.impl;
+
+import com.kaua.ecommerce.auth.application.UseCaseTest;
+import com.kaua.ecommerce.auth.application.exceptions.UseCaseInputCannotBeNullException;
+import com.kaua.ecommerce.auth.application.repositories.MailRepository;
+import com.kaua.ecommerce.auth.application.repositories.UserRepository;
+import com.kaua.ecommerce.auth.application.usecases.users.inputs.CreateMailTokenInput;
+import com.kaua.ecommerce.auth.domain.Fixture;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailType;
+import com.kaua.ecommerce.auth.domain.roles.RoleId;
+import com.kaua.ecommerce.lib.domain.exceptions.DomainException;
+import com.kaua.ecommerce.lib.domain.utils.IdentifierUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+
+class CreateMailTokenUseCaseTest extends UseCaseTest {
+
+    @Mock
+    private MailRepository mailRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private DefaultCreateMailTokenUseCase createMailTokenUseCase;
+
+    @Test
+    void givenAValidValuesWithTypeIsMailConfirmation_whenCallCreateMailToken_thenShouldReturnMailToken() {
+        final var aUser = Fixture.Users.randomUser(new RoleId(IdentifierUtils.generateNewUUID()));
+
+        final var aEmail = aUser.getEmail().value();
+        final var aType = MailType.EMAIL_CONFIRMATION.name();
+
+        final var aInput = new CreateMailTokenInput(aEmail, aType);
+
+        Mockito.when(userRepository.findByEmail(aEmail)).thenReturn(Optional.of(aUser));
+        Mockito.when(mailRepository.findByEmail(aEmail)).thenReturn(List.of());
+        Mockito.when(mailRepository.save(Mockito.any())).thenAnswer(returnsFirstArg());
+
+        final var aOutput = this.createMailTokenUseCase.execute(aInput);
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertEquals(aOutput.userId(), aUser.getId().value().toString());
+        Assertions.assertEquals(aOutput.type(), aType);
+        Assertions.assertNotNull(aOutput.mailId());
+
+        Mockito.verify(userRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(1)).save(Mockito.any());
+    }
+
+    @Test
+    void givenAValidValuesWithTypeIsMailConfirmationAndAlreadyExistsMailToken_whenCallCreateMailToken_thenShouldReturnMailToken() {
+        final var aUser = Fixture.Users.randomUser(new RoleId(IdentifierUtils.generateNewUUID()));
+
+        final var aEmail = aUser.getEmail().value();
+        final var aType = MailType.EMAIL_CONFIRMATION.name();
+
+        final var aInput = new CreateMailTokenInput(aEmail, aType);
+
+        Mockito.when(userRepository.findByEmail(aEmail)).thenReturn(Optional.of(aUser));
+        Mockito.when(mailRepository.findByEmail(aEmail)).thenReturn(List.of(Fixture.Mails.mail(
+                aEmail,
+                aUser.getId().value().toString(),
+                MailType.EMAIL_CONFIRMATION
+        )));
+        Mockito.doNothing().when(mailRepository).deleteByToken(Mockito.any());
+        Mockito.when(mailRepository.save(Mockito.any())).thenAnswer(returnsFirstArg());
+
+        final var aOutput = this.createMailTokenUseCase.execute(aInput);
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertEquals(aOutput.userId(), aUser.getId().value().toString());
+        Assertions.assertEquals(aOutput.type(), aType);
+        Assertions.assertNotNull(aOutput.mailId());
+
+        Mockito.verify(userRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(1)).deleteByToken(Mockito.any());
+        Mockito.verify(mailRepository, Mockito.times(1)).save(Mockito.any());
+    }
+
+    @Test
+    void givenAValidValuesWithTypeIsPasswordReset_whenCallCreateMailToken_thenShouldReturnMailToken() {
+        final var aUser = Fixture.Users.randomUser(new RoleId(IdentifierUtils.generateNewUUID()));
+
+        final var aEmail = aUser.getEmail().value();
+        final var aType = MailType.PASSWORD_RESET.name();
+
+        final var aInput = new CreateMailTokenInput(aEmail, aType);
+
+        Mockito.when(userRepository.findByEmail(aEmail)).thenReturn(Optional.of(aUser));
+        Mockito.when(mailRepository.findByEmail(aEmail)).thenReturn(List.of());
+        Mockito.when(mailRepository.save(Mockito.any())).thenAnswer(returnsFirstArg());
+
+        final var aOutput = this.createMailTokenUseCase.execute(aInput);
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertEquals(aOutput.userId(), aUser.getId().value().toString());
+        Assertions.assertEquals(aOutput.type(), aType);
+        Assertions.assertNotNull(aOutput.mailId());
+
+        Mockito.verify(userRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(1)).save(Mockito.any());
+    }
+
+    @Test
+    void givenAValidValuesWithTypeIsPasswordResetAndAlreadyExistsMailToken_whenCallCreateMailToken_thenShouldReturnMailToken() {
+        final var aUser = Fixture.Users.randomUser(new RoleId(IdentifierUtils.generateNewUUID()));
+
+        final var aEmail = aUser.getEmail().value();
+        final var aType = MailType.PASSWORD_RESET.name();
+
+        final var aInput = new CreateMailTokenInput(aEmail, aType);
+
+        Mockito.when(userRepository.findByEmail(aEmail)).thenReturn(Optional.of(aUser));
+        Mockito.when(mailRepository.findByEmail(aEmail)).thenReturn(List.of(Fixture.Mails.mail(
+                aEmail,
+                aUser.getId().value().toString(),
+                MailType.PASSWORD_RESET
+        )));
+        Mockito.doNothing().when(mailRepository).deleteByToken(Mockito.any());
+        Mockito.when(mailRepository.save(Mockito.any())).thenAnswer(returnsFirstArg());
+
+        final var aOutput = this.createMailTokenUseCase.execute(aInput);
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertEquals(aOutput.userId(), aUser.getId().value().toString());
+        Assertions.assertEquals(aOutput.type(), aType);
+        Assertions.assertNotNull(aOutput.mailId());
+
+        Mockito.verify(userRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(1)).deleteByToken(Mockito.any());
+        Mockito.verify(mailRepository, Mockito.times(1)).save(Mockito.any());
+    }
+
+    @Test
+    void givenAnInvalidType_whenCallCreateMailToken_thenShouldThrowDomainException() {
+        final var aUser = Fixture.Users.randomUser(new RoleId(IdentifierUtils.generateNewUUID()));
+
+        final var aEmail = aUser.getEmail().value();
+        final var aType = "invalid";
+
+        final var expectedErrorMessage = "Invalid mail type %s".formatted(aType);
+
+        final var aInput = new CreateMailTokenInput(aEmail, aType);
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> this.createMailTokenUseCase.execute(aInput));
+
+        Assertions.assertEquals(expectedErrorMessage, aException.getMessage());
+
+        Mockito.verify(userRepository, Mockito.times(0)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(0)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(0)).deleteByToken(Mockito.any());
+        Mockito.verify(mailRepository, Mockito.times(0)).save(Mockito.any());
+    }
+
+    @Test
+    void givenANullInput_whenCallCreateMailToken_thenShouldThrowUseCaseInputCannotBeNullException() {
+        final var expectedErrorMessage = "Input to DefaultCreateMailTokenUseCase cannot be null";
+
+        final var aException = Assertions.assertThrows(UseCaseInputCannotBeNullException.class,
+                () -> this.createMailTokenUseCase.execute(null));
+
+        Assertions.assertEquals(expectedErrorMessage, aException.getMessage());
+
+        Mockito.verify(userRepository, Mockito.times(0)).findByEmail(Mockito.any());
+        Mockito.verify(mailRepository, Mockito.times(0)).findByEmail(Mockito.any());
+        Mockito.verify(mailRepository, Mockito.times(0)).deleteByToken(Mockito.any());
+        Mockito.verify(mailRepository, Mockito.times(0)).save(Mockito.any());
+    }
+
+    @Test
+    void givenANullEmail_whenCallCreateMailToken_thenShouldThrowNotFoundException() {
+        final var aEmail = "email";
+
+        final var expectedErrorMessage = "User with id %s was not found".formatted(aEmail);
+
+        final var aInput = new CreateMailTokenInput(aEmail, MailType.EMAIL_CONFIRMATION.name());
+
+        Mockito.when(userRepository.findByEmail(aEmail)).thenReturn(Optional.empty());
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> this.createMailTokenUseCase.execute(aInput));
+
+        Assertions.assertEquals(expectedErrorMessage, aException.getMessage());
+
+        Mockito.verify(userRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(0)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(0)).deleteByToken(Mockito.any());
+        Mockito.verify(mailRepository, Mockito.times(0)).save(Mockito.any());
+    }
+
+    @Test
+    void givenAUserIsDeleted_whenCallCreateMailToken_thenShouldThrowUserIsDeletedException() {
+        final var aUser = Fixture.Users.randomUser(new RoleId(IdentifierUtils.generateNewUUID()));
+        aUser.markAsDeleted();
+
+        final var aEmail = aUser.getEmail().value();
+
+        final var expectedErrorMessage = "User with id %s is deleted".formatted(aUser.getId().value().toString());
+
+        final var aInput = new CreateMailTokenInput(aEmail, MailType.EMAIL_CONFIRMATION.name());
+
+        Mockito.when(userRepository.findByEmail(aEmail)).thenReturn(Optional.of(aUser));
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> this.createMailTokenUseCase.execute(aInput));
+
+        Assertions.assertEquals(expectedErrorMessage, aException.getMessage());
+
+        Mockito.verify(userRepository, Mockito.times(1)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(0)).findByEmail(aEmail);
+        Mockito.verify(mailRepository, Mockito.times(0)).deleteByToken(Mockito.any());
+        Mockito.verify(mailRepository, Mockito.times(0)).save(Mockito.any());
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/auth/domain/mailtokens/MailId.java
+++ b/domain/src/main/java/com/kaua/ecommerce/auth/domain/mailtokens/MailId.java
@@ -1,0 +1,16 @@
+package com.kaua.ecommerce.auth.domain.mailtokens;
+
+import com.kaua.ecommerce.lib.domain.Identifier;
+
+import java.util.UUID;
+
+public record MailId(UUID value) implements Identifier<UUID> {
+
+    public MailId {
+        this.assertArgumentNotNull(value, "id", "should not be null");
+    }
+
+    public MailId(String value) {
+        this(UUID.fromString(value));
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/auth/domain/mailtokens/MailToken.java
+++ b/domain/src/main/java/com/kaua/ecommerce/auth/domain/mailtokens/MailToken.java
@@ -1,0 +1,174 @@
+package com.kaua.ecommerce.auth.domain.mailtokens;
+
+import com.kaua.ecommerce.auth.domain.users.UserId;
+import com.kaua.ecommerce.lib.domain.AggregateRoot;
+import com.kaua.ecommerce.lib.domain.utils.IdentifierUtils;
+import com.kaua.ecommerce.lib.domain.utils.InstantUtils;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public class MailToken extends AggregateRoot<MailId> {
+
+    private String email;
+    private UserId userId;
+    private String token;
+    private boolean isUsed;
+    private MailType type;
+    private Instant usedAt;
+    private Instant expiresAt;
+    private Instant createdAt;
+
+    private MailToken(
+            final MailId aMailId,
+            final long aVersion,
+            final String aEmail,
+            final UserId aUserId,
+            final String aToken,
+            final boolean aIsUsed,
+            final MailType aType,
+            final Instant aUsedAt,
+            final Instant aExpiresAt,
+            final Instant aCreatedAt
+    ) {
+        super(aMailId, aVersion);
+        this.setEmail(aEmail);
+        this.setUserId(aUserId);
+        this.setToken(aToken);
+        this.setUsed(aIsUsed);
+        this.setType(aType);
+        this.setUsedAt(aUsedAt);
+        this.setExpiresAt(aExpiresAt);
+        this.setCreatedAt(aCreatedAt);
+    }
+
+    public static MailToken newMailToken(
+            final String email,
+            final UserId userId,
+            final String token,
+            final MailType type,
+            final Instant expiresAt
+    ) {
+        final var aMailId = new MailId(IdentifierUtils.generateNewUUID());
+        final var aNow = InstantUtils.now();
+
+        return new MailToken(
+                aMailId,
+                0,
+                email,
+                userId,
+                token,
+                false,
+                type,
+                null,
+                expiresAt,
+                aNow
+        );
+    }
+
+    public static MailToken with(
+            final MailId aMailId,
+            final long aVersion,
+            final String aEmail,
+            final UserId aUserId,
+            final String aToken,
+            final boolean aIsUsed,
+            final MailType aType,
+            final Instant aUsedAt,
+            final Instant aExpiresAt,
+            final Instant aCreatedAt
+    ) {
+        return new MailToken(
+                aMailId,
+                aVersion,
+                aEmail,
+                aUserId,
+                aToken,
+                aIsUsed,
+                aType,
+                aUsedAt,
+                aExpiresAt,
+                aCreatedAt
+        );
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    private void setEmail(final String email) {
+        this.email = this.assertArgumentNotEmpty(email, "email", "should not be empty");
+    }
+
+    public UserId getUserId() {
+        return userId;
+    }
+
+    private void setUserId(final UserId userId) {
+        this.userId = this.assertArgumentNotNull(userId, "userId", "should not be null");
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    private void setToken(final String token) {
+        this.token = this.assertArgumentNotEmpty(token, "token", "should not be empty");
+    }
+
+    public boolean isUsed() {
+        return isUsed;
+    }
+
+    private void setUsed(final boolean used) {
+        isUsed = used;
+    }
+
+    public MailType getType() {
+        return type;
+    }
+
+    private void setType(final MailType type) {
+        this.type = this.assertArgumentNotNull(type, "type", "should not be null");
+    }
+
+    public Optional<Instant> getUsedAt() {
+        return Optional.ofNullable(usedAt);
+    }
+
+    private void setUsedAt(final Instant usedAt) {
+        this.usedAt = usedAt;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    private void setExpiresAt(final Instant expiresAt) {
+        this.expiresAt = this.assertArgumentNotNull(expiresAt, "expiresAt", "should not be null");
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    private void setCreatedAt(final Instant createdAt) {
+        this.createdAt = this.assertArgumentNotNull(createdAt, "createdAt", "should not be null");
+    }
+
+    @Override
+    public String toString() {
+        return "MailToken(" +
+                "id='" + getId().value() + '\'' +
+                ", email=" + email +
+                ", userId=" + userId.value() +
+                ", token='" + token + '\'' +
+                ", isUsed=" + isUsed +
+                ", type=" + type.name() +
+                ", usedAt=" + getUsedAt().orElse(null) +
+                ", expiresAt=" + expiresAt +
+                ", createdAt=" + createdAt +
+                ", version=" + getVersion() +
+                ')';
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/auth/domain/mailtokens/MailToken.java
+++ b/domain/src/main/java/com/kaua/ecommerce/auth/domain/mailtokens/MailToken.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 public class MailToken extends AggregateRoot<MailId> {
 
+    private static final String SHOULD_NOT_BE_NULL = "should not be null";
+
     private String email;
     private UserId userId;
     private String token;
@@ -105,7 +107,7 @@ public class MailToken extends AggregateRoot<MailId> {
     }
 
     private void setUserId(final UserId userId) {
-        this.userId = this.assertArgumentNotNull(userId, "userId", "should not be null");
+        this.userId = this.assertArgumentNotNull(userId, "userId", SHOULD_NOT_BE_NULL);
     }
 
     public String getToken() {
@@ -129,7 +131,7 @@ public class MailToken extends AggregateRoot<MailId> {
     }
 
     private void setType(final MailType type) {
-        this.type = this.assertArgumentNotNull(type, "type", "should not be null");
+        this.type = this.assertArgumentNotNull(type, "type", SHOULD_NOT_BE_NULL);
     }
 
     public Optional<Instant> getUsedAt() {
@@ -145,7 +147,7 @@ public class MailToken extends AggregateRoot<MailId> {
     }
 
     private void setExpiresAt(final Instant expiresAt) {
-        this.expiresAt = this.assertArgumentNotNull(expiresAt, "expiresAt", "should not be null");
+        this.expiresAt = this.assertArgumentNotNull(expiresAt, "expiresAt", SHOULD_NOT_BE_NULL);
     }
 
     public Instant getCreatedAt() {
@@ -153,7 +155,7 @@ public class MailToken extends AggregateRoot<MailId> {
     }
 
     private void setCreatedAt(final Instant createdAt) {
-        this.createdAt = this.assertArgumentNotNull(createdAt, "createdAt", "should not be null");
+        this.createdAt = this.assertArgumentNotNull(createdAt, "createdAt", SHOULD_NOT_BE_NULL);
     }
 
     @Override

--- a/domain/src/main/java/com/kaua/ecommerce/auth/domain/mailtokens/MailType.java
+++ b/domain/src/main/java/com/kaua/ecommerce/auth/domain/mailtokens/MailType.java
@@ -1,0 +1,16 @@
+package com.kaua.ecommerce.auth.domain.mailtokens;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum MailType {
+
+    EMAIL_CONFIRMATION,
+    PASSWORD_RESET;
+
+    public static Optional<MailType> of(final String value) {
+        return Arrays.stream(values())
+                .filter(it -> it.name().equalsIgnoreCase(value))
+                .findFirst();
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/auth/domain/Fixture.java
+++ b/domain/src/test/java/com/kaua/ecommerce/auth/domain/Fixture.java
@@ -1,14 +1,18 @@
 package com.kaua.ecommerce.auth.domain;
 
+import com.kaua.ecommerce.auth.domain.mailtokens.MailToken;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailType;
 import com.kaua.ecommerce.auth.domain.roles.Role;
 import com.kaua.ecommerce.auth.domain.roles.RoleDescription;
 import com.kaua.ecommerce.auth.domain.roles.RoleId;
 import com.kaua.ecommerce.auth.domain.roles.RoleName;
 import com.kaua.ecommerce.auth.domain.users.*;
 import com.kaua.ecommerce.lib.domain.utils.IdentifierUtils;
+import com.kaua.ecommerce.lib.domain.utils.InstantUtils;
 import com.kaua.ecommerce.lib.domain.utils.RandomStringUtils;
 import net.datafaker.Faker;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.UUID;
 
@@ -16,7 +20,22 @@ public final class Fixture {
 
     private static final Faker faker = new Faker();
 
-    private Fixture() {}
+    private Fixture() {
+    }
+
+    public static final class Mails {
+        private Mails() {}
+
+        public static MailToken mail(final String aEmail, final String aUserId, final MailType aType) {
+            return MailToken.newMailToken(
+                    aEmail,
+                    new UserId(aUserId),
+                    IdentifierUtils.generateNewIdWithoutHyphen(),
+                    aType,
+                    InstantUtils.now().plus(3, ChronoUnit.DAYS)
+            );
+        }
+    }
 
     public static final class Users {
 

--- a/domain/src/test/java/com/kaua/ecommerce/auth/domain/mailtokens/MailTokenTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/auth/domain/mailtokens/MailTokenTest.java
@@ -1,0 +1,120 @@
+package com.kaua.ecommerce.auth.domain.mailtokens;
+
+import com.kaua.ecommerce.auth.domain.Fixture;
+import com.kaua.ecommerce.auth.domain.UnitTest;
+import com.kaua.ecommerce.auth.domain.users.UserId;
+import com.kaua.ecommerce.lib.domain.utils.IdentifierUtils;
+import com.kaua.ecommerce.lib.domain.utils.InstantUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+class MailTokenTest extends UnitTest {
+
+    @Test
+    void givenAValidValues_whenCallNewMailToken_thenShouldReturnAMailToken() {
+        final var aMail = Fixture.Users.email();
+        final var aUserId = new UserId(IdentifierUtils.generateNewUUID());
+        final var aToken = IdentifierUtils.generateNewIdWithoutHyphen();
+        final var aType = MailType.EMAIL_CONFIRMATION;
+        final var aExpiresAt = InstantUtils.now().plus(10, ChronoUnit.HOURS);
+
+        final var aMailToken = MailToken.newMailToken(
+                aMail,
+                aUserId,
+                aToken,
+                aType,
+                aExpiresAt
+        );
+
+        Assertions.assertNotNull(aMailToken);
+        Assertions.assertNotNull(aMailToken.getId());
+        Assertions.assertEquals(aMail, aMailToken.getEmail());
+        Assertions.assertEquals(aUserId, aMailToken.getUserId());
+        Assertions.assertEquals(aToken, aMailToken.getToken());
+        Assertions.assertEquals(aType, aMailToken.getType());
+        Assertions.assertFalse(aMailToken.isUsed());
+        Assertions.assertTrue(aMailToken.getUsedAt().isEmpty());
+        Assertions.assertEquals(aExpiresAt, aMailToken.getExpiresAt());
+        Assertions.assertNotNull(aMailToken.getCreatedAt());
+    }
+
+    @Test
+    void givenAValidValues_whenCallWith_thenShouldReturnAMailToken() {
+        final var aMailId = new MailId(IdentifierUtils.generateNewId());
+        final var aVersion = 0;
+        final var aMail = Fixture.Users.email();
+        final var aUserId = new UserId(IdentifierUtils.generateNewUUID());
+        final var aToken = IdentifierUtils.generateNewIdWithoutHyphen();
+        final var aIsUsed = false;
+        final var aType = MailType.EMAIL_CONFIRMATION;
+        final Instant aUsedAt = null;
+        final var aExpiresAt = InstantUtils.now().plus(10, ChronoUnit.HOURS);
+        final var aCreatedAt = InstantUtils.now();
+
+        final var aMailToken = MailToken.with(
+                aMailId,
+                aVersion,
+                aMail,
+                aUserId,
+                aToken,
+                aIsUsed,
+                aType,
+                aUsedAt,
+                aExpiresAt,
+                aCreatedAt
+        );
+
+        Assertions.assertNotNull(aMailToken);
+        Assertions.assertEquals(aMailId, aMailToken.getId());
+        Assertions.assertEquals(aVersion, aMailToken.getVersion());
+        Assertions.assertEquals(aMail, aMailToken.getEmail());
+        Assertions.assertEquals(aUserId, aMailToken.getUserId());
+        Assertions.assertEquals(aToken, aMailToken.getToken());
+        Assertions.assertEquals(aIsUsed, aMailToken.isUsed());
+        Assertions.assertEquals(aType, aMailToken.getType());
+        Assertions.assertTrue(aMailToken.getUsedAt().isEmpty());
+        Assertions.assertEquals(aExpiresAt, aMailToken.getExpiresAt());
+        Assertions.assertEquals(aCreatedAt, aMailToken.getCreatedAt());
+    }
+
+    @Test
+    void testCallMailTokenToString() {
+        final var aMail = Fixture.Users.email();
+        final var aUserId = new UserId(IdentifierUtils.generateNewUUID());
+        final var aToken = IdentifierUtils.generateNewIdWithoutHyphen();
+        final var aType = MailType.EMAIL_CONFIRMATION;
+        final var aExpiresAt = InstantUtils.now().plus(10, ChronoUnit.HOURS);
+
+        final var aMailToken = MailToken.newMailToken(
+                aMail,
+                aUserId,
+                aToken,
+                aType,
+                aExpiresAt
+        );
+
+        final var aMailTokenToString = aMailToken.toString();
+
+        Assertions.assertNotNull(aMailTokenToString);
+        Assertions.assertTrue(aMailTokenToString.contains("MailToken"));
+        Assertions.assertTrue(aMailTokenToString.contains("email=" + aMail));
+        Assertions.assertTrue(aMailTokenToString.contains("userId=" + aUserId.value()));
+        Assertions.assertTrue(aMailTokenToString.contains("type=" + aType.name()));
+        Assertions.assertTrue(aMailTokenToString.contains("isUsed=false"));
+        Assertions.assertTrue(aMailTokenToString.contains("usedAt=null"));
+        Assertions.assertTrue(aMailTokenToString.contains("expiresAt=" + aExpiresAt));
+        Assertions.assertTrue(aMailTokenToString.contains("createdAt=" + aMailToken.getCreatedAt()));
+    }
+
+    @Test
+    void givenAValidValue_whenCallMailTypeOf_thenShouldReturnMailType() {
+        final var aMailType = MailType.EMAIL_CONFIRMATION;
+        final var aMailTypeOf = MailType.of(aMailType.name());
+
+        Assertions.assertTrue(aMailTypeOf.isPresent());
+        Assertions.assertEquals(aMailType, aMailTypeOf.get());
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/configurations/usecases/UserUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/configurations/usecases/UserUseCaseConfig.java
@@ -2,6 +2,7 @@ package com.kaua.ecommerce.auth.infrastructure.configurations.usecases;
 
 import com.kaua.ecommerce.auth.application.gateways.CryptographyGateway;
 import com.kaua.ecommerce.auth.application.gateways.MfaGateway;
+import com.kaua.ecommerce.auth.application.repositories.MailRepository;
 import com.kaua.ecommerce.auth.application.repositories.RoleRepository;
 import com.kaua.ecommerce.auth.application.repositories.UserRepository;
 import com.kaua.ecommerce.auth.application.usecases.users.*;
@@ -18,17 +19,20 @@ public class UserUseCaseConfig {
     private final CryptographyGateway cryptographyGateway;
     private final RoleRepository roleRepository;
     private final MfaGateway mfaGateway;
+    private final MailRepository mailRepository;
 
     public UserUseCaseConfig(
             final UserRepository userRepository,
             final CryptographyGateway cryptographyGateway,
             final RoleRepository roleRepository,
-            final MfaGateway mfaGateway
+            final MfaGateway mfaGateway,
+            final MailRepository mailRepository
     ) {
         this.userRepository = Objects.requireNonNull(userRepository);
         this.cryptographyGateway = Objects.requireNonNull(cryptographyGateway);
         this.roleRepository = Objects.requireNonNull(roleRepository);
         this.mfaGateway = Objects.requireNonNull(mfaGateway);
+        this.mailRepository = Objects.requireNonNull(mailRepository);
     }
 
     @Bean
@@ -74,5 +78,10 @@ public class UserUseCaseConfig {
     @Bean
     public GetUserByIdUseCase getUserByIdUseCase() {
         return new DefaultGetUserByIdUseCase(userRepository, roleRepository);
+    }
+
+    @Bean
+    public CreateMailTokenUseCase createMailTokenUseCase() {
+        return new DefaultCreateMailTokenUseCase(mailRepository, userRepository);
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/MailRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/MailRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.kaua.ecommerce.auth.infrastructure.mailtokens;
+
+import com.kaua.ecommerce.auth.application.repositories.MailRepository;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailToken;
+import com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity;
+import com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntityRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class MailRepositoryImpl implements MailRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(MailRepositoryImpl.class);
+
+    private final MailTokenJpaEntityRepository mailTokenJpaEntityRepository;
+
+    public MailRepositoryImpl(final MailTokenJpaEntityRepository mailTokenJpaEntityRepository) {
+        this.mailTokenJpaEntityRepository = Objects.requireNonNull(mailTokenJpaEntityRepository);
+    }
+
+    @Override
+    public MailToken save(final MailToken mailToken) {
+        log.debug("Saving mail token: {}", mailToken);
+
+        final var mailTokenJpaEntity = MailTokenJpaEntity.toEntity(mailToken);
+        final var savedMailTokenJpaEntity = this.mailTokenJpaEntityRepository
+                .save(mailTokenJpaEntity).toDomain();
+
+        log.info("Mail token saved: {}", savedMailTokenJpaEntity);
+        return savedMailTokenJpaEntity;
+    }
+
+    @Override
+    public List<MailToken> findByEmail(final String email) {
+        return this.mailTokenJpaEntityRepository.findByEmail(email)
+                .stream()
+                .map(MailTokenJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void deleteByToken(final String token) {
+        log.debug("Deleting mail token by token: {}", token);
+        this.mailTokenJpaEntityRepository.deleteByToken(token);
+        log.info("Mail token deleted by token: {}", token);
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/persistence/MailTokenJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/persistence/MailTokenJpaEntity.java
@@ -1,0 +1,179 @@
+package com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence;
+
+import com.kaua.ecommerce.auth.domain.mailtokens.MailId;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailToken;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailType;
+import com.kaua.ecommerce.auth.domain.users.UserId;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "mail_tokens")
+public class MailTokenJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "token", nullable = false)
+    private String token;
+
+    @Column(name = "is_used", nullable = false)
+    private boolean isUsed;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private MailType type;
+
+    @Column(name = "used_at")
+    private Instant usedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Version
+    private Long version;
+
+    public MailTokenJpaEntity() {
+    }
+
+    private MailTokenJpaEntity(
+            final UUID id,
+            final String email,
+            final UUID userId,
+            final String token,
+            final boolean isUsed,
+            final MailType type,
+            final Instant usedAt,
+            final Instant expiresAt,
+            final Instant createdAt,
+            final Long version
+    ) {
+        this.id = id;
+        this.email = email;
+        this.userId = userId;
+        this.token = token;
+        this.isUsed = isUsed;
+        this.type = type;
+        this.usedAt = usedAt;
+        this.expiresAt = expiresAt;
+        this.createdAt = createdAt;
+        this.version = version;
+    }
+
+    public static MailTokenJpaEntity toEntity(final MailToken aMailToken) {
+        return new MailTokenJpaEntity(
+                aMailToken.getId().value(),
+                aMailToken.getEmail(),
+                aMailToken.getUserId().value(),
+                aMailToken.getToken(),
+                aMailToken.isUsed(),
+                aMailToken.getType(),
+                aMailToken.getUsedAt().orElse(null),
+                aMailToken.getExpiresAt(),
+                aMailToken.getCreatedAt(),
+                aMailToken.getVersion()
+        );
+    }
+
+    public MailToken toDomain() {
+        return MailToken.with(
+                new MailId(getId()),
+                getVersion(),
+                getEmail(),
+                new UserId(getUserId()),
+                getToken(),
+                isUsed(),
+                getType(),
+                getUsedAt(),
+                getExpiresAt(),
+                getCreatedAt()
+        );
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public boolean isUsed() {
+        return isUsed;
+    }
+
+    public void setUsed(boolean used) {
+        isUsed = used;
+    }
+
+    public MailType getType() {
+        return type;
+    }
+
+    public void setType(MailType type) {
+        this.type = type;
+    }
+
+    public Instant getUsedAt() {
+        return usedAt;
+    }
+
+    public void setUsedAt(Instant usedAt) {
+        this.usedAt = usedAt;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/persistence/MailTokenJpaEntityRepository.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/persistence/MailTokenJpaEntityRepository.java
@@ -1,0 +1,13 @@
+package com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MailTokenJpaEntityRepository extends JpaRepository<MailTokenJpaEntity, UUID> {
+
+    List<MailTokenJpaEntity> findByEmail(String email);
+
+    void deleteByToken(String token);
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/rest/MailTokenRestApi.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/rest/MailTokenRestApi.java
@@ -1,0 +1,46 @@
+package com.kaua.ecommerce.auth.infrastructure.rest;
+
+import com.kaua.ecommerce.auth.application.usecases.users.outputs.CreateMailTokenOutput;
+import com.kaua.ecommerce.auth.infrastructure.rest.models.req.CreateMailTokenRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Mail Token", description = "Mail Token API")
+@RequestMapping(value = "/v1/mail-tokens")
+public interface MailTokenRestApi {
+
+    @PostMapping(
+            value = "/email-confirmation",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @Operation(summary = "Create a email confirmation token")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Email confirmation token created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid input"),
+            @ApiResponse(responseCode = "422", description = "A validation error was observed"),
+            @ApiResponse(responseCode = "500", description = "An unexpected error occurred")
+    })
+    ResponseEntity<CreateMailTokenOutput> createEmailConfirmationToken(@RequestBody CreateMailTokenRequest request);
+
+    @PostMapping(
+            value = "/password-reset",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @Operation(summary = "Create a password reset token")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Password reset token created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid input"),
+            @ApiResponse(responseCode = "422", description = "A validation error was observed"),
+            @ApiResponse(responseCode = "500", description = "An unexpected error occurred")
+    })
+    ResponseEntity<CreateMailTokenOutput> createPasswordResetToken(@RequestBody CreateMailTokenRequest request);
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/rest/controllers/MailTokenRestController.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/rest/controllers/MailTokenRestController.java
@@ -1,0 +1,59 @@
+package com.kaua.ecommerce.auth.infrastructure.rest.controllers;
+
+import com.kaua.ecommerce.auth.application.usecases.users.CreateMailTokenUseCase;
+import com.kaua.ecommerce.auth.application.usecases.users.inputs.CreateMailTokenInput;
+import com.kaua.ecommerce.auth.application.usecases.users.outputs.CreateMailTokenOutput;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailType;
+import com.kaua.ecommerce.auth.infrastructure.rest.MailTokenRestApi;
+import com.kaua.ecommerce.auth.infrastructure.rest.models.req.CreateMailTokenRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
+
+@RestController
+public class MailTokenRestController implements MailTokenRestApi {
+
+    private static final Logger log = LoggerFactory.getLogger(MailTokenRestController.class);
+
+    private final CreateMailTokenUseCase createMailTokenUseCase;
+
+    public MailTokenRestController(final CreateMailTokenUseCase createMailTokenUseCase) {
+        this.createMailTokenUseCase = Objects.requireNonNull(createMailTokenUseCase);
+    }
+
+    @Override
+    public ResponseEntity<CreateMailTokenOutput> createEmailConfirmationToken(
+            final CreateMailTokenRequest request
+    ) {
+        log.debug("Received request to create email confirmation token: {}", request);
+
+        final var aInput = new CreateMailTokenInput(
+                request.email(),
+                MailType.EMAIL_CONFIRMATION.name()
+        );
+
+        final var aOutput = this.createMailTokenUseCase.execute(aInput);
+        log.info("Email confirmation token created: {}", aOutput);
+        return ResponseEntity.status(HttpStatus.CREATED).body(aOutput);
+    }
+
+    @Override
+    public ResponseEntity<CreateMailTokenOutput> createPasswordResetToken(
+            final CreateMailTokenRequest request
+    ) {
+        log.debug("Received request to create password reset token: {}", request);
+
+        final var aInput = new CreateMailTokenInput(
+                request.email(),
+                MailType.PASSWORD_RESET.name()
+        );
+
+        final var aOutput = this.createMailTokenUseCase.execute(aInput);
+        log.info("Password reset token created: {}", aOutput);
+        return ResponseEntity.status(HttpStatus.CREATED).body(aOutput);
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/rest/models/req/CreateMailTokenRequest.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/rest/models/req/CreateMailTokenRequest.java
@@ -1,0 +1,8 @@
+package com.kaua.ecommerce.auth.infrastructure.rest.models.req;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CreateMailTokenRequest(
+        @JsonProperty("email") String email
+) {
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/users/UserRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/auth/infrastructure/users/UserRepositoryImpl.java
@@ -50,6 +50,12 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByEmail(final String email) {
+        return this.userJpaEntityRepository.findByEmail(email)
+                .map(UserJpaEntity::toDomain);
+    }
+
+    @Override
     public boolean existsByEmail(String email) {
         return this.userJpaEntityRepository.existsByEmail(email);
     }

--- a/infrastructure/src/main/resources/db/migration/U05__create-mail-tokens-table.sql
+++ b/infrastructure/src/main/resources/db/migration/U05__create-mail-tokens-table.sql
@@ -1,0 +1,1 @@
+DROP TABLE mail_tokens;

--- a/infrastructure/src/main/resources/db/migration/V05__create-mail-tokens-table.sql
+++ b/infrastructure/src/main/resources/db/migration/V05__create-mail-tokens-table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE mail_tokens (
+    id UUID PRIMARY KEY,
+    email VARCHAR(255) NOT NULL,
+    user_id UUID NOT NULL,
+    token VARCHAR(34) NOT NULL UNIQUE,
+    is_used BOOLEAN NOT NULL DEFAULT FALSE,
+    type VARCHAR(150) NOT NULL,
+    used_at TIMESTAMP WITH TIME ZONE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    version INT NOT NULL
+);
+
+CREATE INDEX idx_mail_tokens_email ON mail_tokens(email);
+CREATE INDEX idx_mail_tokens_token ON mail_tokens(token);

--- a/infrastructure/src/test/java/com/kaua/ecommerce/auth/config/JpaCleanUpExtension.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/auth/config/JpaCleanUpExtension.java
@@ -1,5 +1,6 @@
 package com.kaua.ecommerce.auth.config;
 
+import com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntityRepository;
 import com.kaua.ecommerce.auth.infrastructure.oauth2.clients.persistence.ClientJpaEntityRepository;
 import com.kaua.ecommerce.auth.infrastructure.roles.persistence.RoleJpaEntityRepository;
 import com.kaua.ecommerce.auth.infrastructure.users.persistence.UserJpaEntityRepository;
@@ -20,7 +21,8 @@ public class JpaCleanUpExtension implements BeforeEachCallback {
         cleanUp(List.of(
                 appContext.getBean(UserJpaEntityRepository.class),
                 appContext.getBean(RoleJpaEntityRepository.class),
-                appContext.getBean(ClientJpaEntityRepository.class)
+                appContext.getBean(ClientJpaEntityRepository.class),
+                appContext.getBean(MailTokenJpaEntityRepository.class)
         ));
     }
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/MailTokenRepositoryImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/MailTokenRepositoryImplTest.java
@@ -1,0 +1,95 @@
+package com.kaua.ecommerce.auth.infrastructure.mailtokens;
+
+import com.kaua.ecommerce.auth.domain.Fixture;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailType;
+import com.kaua.ecommerce.auth.infrastructure.DatabaseRepositoryTest;
+import com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity;
+import com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntityRepository;
+import com.kaua.ecommerce.lib.domain.utils.IdentifierUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Set;
+
+@DatabaseRepositoryTest
+class MailTokenRepositoryImplTest {
+
+    @Autowired
+    private MailRepositoryImpl mailRepositoryImpl;
+
+    @Autowired
+    private MailTokenJpaEntityRepository mailTokenJpaEntityRepository;
+
+    @Test
+    void givenAValidValues_whenCallSave_thenSaveMailToken() {
+        final var aMail = Fixture.Mails.mail(
+                "testes.tess@gmail.com",
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+
+        Assertions.assertEquals(0, mailTokenJpaEntityRepository.count());
+
+        final var aOutput = this.mailRepositoryImpl.save(aMail);
+
+        Assertions.assertEquals(1, mailTokenJpaEntityRepository.count());
+
+        Assertions.assertEquals(aMail.getId().value(), aOutput.getId().value());
+        Assertions.assertEquals(aMail.getEmail(), aOutput.getEmail());
+        Assertions.assertEquals(aMail.getUserId().value(), aOutput.getUserId().value());
+        Assertions.assertEquals(aMail.getToken(), aOutput.getToken());
+        Assertions.assertEquals(aMail.getType(), aOutput.getType());
+        Assertions.assertEquals(aMail.isUsed(), aOutput.isUsed());
+        Assertions.assertEquals(aMail.getUsedAt(), aOutput.getUsedAt());
+        Assertions.assertEquals(aMail.getExpiresAt(), aOutput.getExpiresAt());
+        Assertions.assertEquals(aMail.getCreatedAt(), aOutput.getCreatedAt());
+    }
+
+    @Test
+    void givenAnPrePersistedTokens_whenCallFindByEmail_thenReturnMailsTokens() {
+        final var aEmail = Fixture.Users.email();
+        final var aUserId = IdentifierUtils.generateNewId();
+        final var aMailOne = Fixture.Mails.mail(
+                aEmail,
+                aUserId,
+                MailType.EMAIL_CONFIRMATION
+        );
+
+        final var aMailTwo = Fixture.Mails.mail(
+                aEmail,
+                aUserId,
+                MailType.PASSWORD_RESET
+        );
+
+        mailTokenJpaEntityRepository.saveAllAndFlush(Set.of(
+                MailTokenJpaEntity.toEntity(aMailOne),
+                MailTokenJpaEntity.toEntity(aMailTwo)
+        ));
+
+        Assertions.assertEquals(2, mailTokenJpaEntityRepository.count());
+
+        final var aOutput = this.mailRepositoryImpl.findByEmail(aEmail);
+
+        Assertions.assertEquals(2, aOutput.size());
+    }
+
+    @Test
+    void givenAnPrePersistedMail_whenCallDeleteByToken_thenDeleteMailToken() {
+        final var aEmail = Fixture.Users.email();
+        final var aUserId = IdentifierUtils.generateNewId();
+        final var aMail = Fixture.Mails.mail(
+                aEmail,
+                aUserId,
+                MailType.EMAIL_CONFIRMATION
+        );
+
+        mailTokenJpaEntityRepository.saveAndFlush(MailTokenJpaEntity.toEntity(aMail));
+
+        Assertions.assertEquals(1, mailTokenJpaEntityRepository.count());
+
+        this.mailRepositoryImpl.deleteByToken(aMail.getToken());
+
+        Assertions.assertEquals(0, mailTokenJpaEntityRepository.count());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/persistence/MailTokenJpaEntityRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/mailtokens/persistence/MailTokenJpaEntityRepositoryTest.java
@@ -1,0 +1,252 @@
+package com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence;
+
+import com.kaua.ecommerce.auth.domain.Fixture;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailType;
+import com.kaua.ecommerce.auth.infrastructure.DatabaseRepositoryTest;
+import com.kaua.ecommerce.lib.domain.utils.IdentifierUtils;
+import org.hibernate.PropertyValueException;
+import org.hibernate.id.IdentifierGenerationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+
+@DatabaseRepositoryTest
+class MailTokenJpaEntityRepositoryTest {
+
+    @Autowired
+    private MailTokenJpaEntityRepository mailTokenJpaEntityRepository;
+
+    @Test
+    void givenAValidEntity_whenCallSave_shouldReturnAnEntity() {
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+
+        final var aEntitySaved = mailTokenJpaEntityRepository.save(aEntity);
+
+        Assertions.assertNotNull(aEntitySaved);
+        Assertions.assertEquals(aEntity.getId(), aEntitySaved.getId());
+        Assertions.assertEquals(aEntity.getUserId(), aEntitySaved.getUserId());
+        Assertions.assertEquals(aEntity.getEmail(), aEntitySaved.getEmail());
+        Assertions.assertEquals(aEntity.getToken(), aEntitySaved.getToken());
+        Assertions.assertEquals(aEntity.isUsed(), aEntitySaved.isUsed());
+        Assertions.assertEquals(aEntity.getType(), aEntitySaved.getType());
+        Assertions.assertEquals(aEntity.getUsedAt(), aEntitySaved.getUsedAt());
+        Assertions.assertEquals(aEntity.getExpiresAt(), aEntitySaved.getExpiresAt());
+        Assertions.assertEquals(aEntity.getCreatedAt(), aEntitySaved.getCreatedAt());
+    }
+
+    @Test
+    void givenAnInvalidNullEmail_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "email";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity.email";
+
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setEmail(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullUserId_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "userId";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity.userId";
+
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setUserId(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullToken_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "token";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity.token";
+
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setToken(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnFalseIsUsed_whenCallSave_shouldReturnAnEntity() {
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setUsed(false);
+
+        final var aEntitySaved = Assertions.assertDoesNotThrow(
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        Assertions.assertNotNull(aEntitySaved);
+        Assertions.assertEquals(aEntity.getId(), aEntitySaved.getId());
+        Assertions.assertEquals(aEntity.getUserId(), aEntitySaved.getUserId());
+        Assertions.assertEquals(aEntity.getEmail(), aEntitySaved.getEmail());
+        Assertions.assertEquals(aEntity.getToken(), aEntitySaved.getToken());
+        Assertions.assertEquals(aEntity.isUsed(), aEntitySaved.isUsed());
+        Assertions.assertEquals(aEntity.getType(), aEntitySaved.getType());
+        Assertions.assertEquals(aEntity.getUsedAt(), aEntitySaved.getUsedAt());
+        Assertions.assertEquals(aEntity.getExpiresAt(), aEntitySaved.getExpiresAt());
+        Assertions.assertEquals(aEntity.getCreatedAt(), aEntitySaved.getCreatedAt());
+    }
+
+    @Test
+    void givenAnInvalidNullType_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "type";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity.type";
+
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setType(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullExpiresAt_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "expiresAt";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity.expiresAt";
+
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setExpiresAt(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullCreatedAt_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "createdAt";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity.createdAt";
+
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setCreatedAt(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
+        final var expectedErrorMessage = "Identifier of entity 'com.kaua.ecommerce.auth.infrastructure.mailtokens.persistence.MailTokenJpaEntity' must be manually assigned before calling 'persist()'";
+
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setId(null);
+
+        final var actualException = Assertions.assertThrows(JpaSystemException.class,
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(IdentifierGenerationException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAValidNullUsedAt_whenCallSave_shouldReturnAnEntity() {
+        final var aMailToken = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+        final var aEntity = MailTokenJpaEntity.toEntity(aMailToken);
+        aEntity.setUsedAt(null);
+
+        final var aEntitySaved = Assertions.assertDoesNotThrow(
+                () -> mailTokenJpaEntityRepository.save(aEntity));
+
+        Assertions.assertNotNull(aEntitySaved);
+        Assertions.assertEquals(aEntity.getId(), aEntitySaved.getId());
+        Assertions.assertEquals(aEntity.getUserId(), aEntitySaved.getUserId());
+        Assertions.assertEquals(aEntity.getEmail(), aEntitySaved.getEmail());
+        Assertions.assertEquals(aEntity.getToken(), aEntitySaved.getToken());
+        Assertions.assertEquals(aEntity.isUsed(), aEntitySaved.isUsed());
+        Assertions.assertEquals(aEntity.getType(), aEntitySaved.getType());
+        Assertions.assertEquals(aEntity.getUsedAt(), aEntitySaved.getUsedAt());
+        Assertions.assertEquals(aEntity.getExpiresAt(), aEntitySaved.getExpiresAt());
+        Assertions.assertEquals(aEntity.getCreatedAt(), aEntitySaved.getCreatedAt());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/rest/MailTokenRestApiTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/rest/MailTokenRestApiTest.java
@@ -37,45 +37,6 @@ class MailTokenRestApiTest {
     @Captor
     private ArgumentCaptor<CreateMailTokenInput> createMailTokenInputCaptor;
 
-//    @MockBean
-//    private CreateUserUseCase createUserUseCase;
-//
-//    @MockBean
-//    private CreateUserMfaUseCase createUserMfaUseCase;
-//
-//    @MockBean
-//    private ConfirmUserMfaDeviceUseCase confirmUserMfaDeviceUseCase;
-//
-//    @MockBean
-//    private DisableUserMfaUseCase disableUserMfaUseCase;
-//
-//    @MockBean
-//    private UpdateUserUseCase updateUserUseCase;
-//
-//    @MockBean
-//    private MarkAsDeleteUserUseCase markAsDeleteUserUseCase;
-//
-//    @MockBean
-//    private AddRolesToUserUseCase addRolesToUserUseCase;
-//
-//    @MockBean
-//    private RemoveUserRoleUseCase removeUserRoleUseCase;
-//
-//    @MockBean
-//    private GetUserByIdUseCase getUserByIdUseCase;
-//
-//    @Captor
-//    private ArgumentCaptor<CreateUserInput> createUserInputCaptor;
-//
-//    @Captor
-//    private ArgumentCaptor<CreateUserMfaInput> createUserMfaInputCaptor;
-//
-//    @Captor
-//    private ArgumentCaptor<ConfirmUserMfaDeviceInput> confirmUserMfaDeviceInputCaptor;
-//
-//    @Captor
-//    private ArgumentCaptor<UpdateUserInput> updateUserInputCaptor;
-
     @Test
     void givenAValidRequest_whenCallCreateMailConfirmationToken_thenReturnMailIdAndUserId() throws Exception {
         final var aMail = Fixture.Mails.mail(

--- a/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/rest/MailTokenRestApiTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/rest/MailTokenRestApiTest.java
@@ -1,0 +1,160 @@
+package com.kaua.ecommerce.auth.infrastructure.rest;
+
+import com.kaua.ecommerce.auth.application.usecases.users.CreateMailTokenUseCase;
+import com.kaua.ecommerce.auth.application.usecases.users.inputs.CreateMailTokenInput;
+import com.kaua.ecommerce.auth.application.usecases.users.outputs.CreateMailTokenOutput;
+import com.kaua.ecommerce.auth.domain.Fixture;
+import com.kaua.ecommerce.auth.domain.mailtokens.MailType;
+import com.kaua.ecommerce.auth.infrastructure.ApiTest;
+import com.kaua.ecommerce.auth.infrastructure.ControllerTest;
+import com.kaua.ecommerce.auth.infrastructure.rest.controllers.MailTokenRestController;
+import com.kaua.ecommerce.lib.domain.utils.IdentifierUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ControllerTest(controllers = MailTokenRestController.class)
+class MailTokenRestApiTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private CreateMailTokenUseCase createMailTokenUseCase;
+
+    @Captor
+    private ArgumentCaptor<CreateMailTokenInput> createMailTokenInputCaptor;
+
+//    @MockBean
+//    private CreateUserUseCase createUserUseCase;
+//
+//    @MockBean
+//    private CreateUserMfaUseCase createUserMfaUseCase;
+//
+//    @MockBean
+//    private ConfirmUserMfaDeviceUseCase confirmUserMfaDeviceUseCase;
+//
+//    @MockBean
+//    private DisableUserMfaUseCase disableUserMfaUseCase;
+//
+//    @MockBean
+//    private UpdateUserUseCase updateUserUseCase;
+//
+//    @MockBean
+//    private MarkAsDeleteUserUseCase markAsDeleteUserUseCase;
+//
+//    @MockBean
+//    private AddRolesToUserUseCase addRolesToUserUseCase;
+//
+//    @MockBean
+//    private RemoveUserRoleUseCase removeUserRoleUseCase;
+//
+//    @MockBean
+//    private GetUserByIdUseCase getUserByIdUseCase;
+//
+//    @Captor
+//    private ArgumentCaptor<CreateUserInput> createUserInputCaptor;
+//
+//    @Captor
+//    private ArgumentCaptor<CreateUserMfaInput> createUserMfaInputCaptor;
+//
+//    @Captor
+//    private ArgumentCaptor<ConfirmUserMfaDeviceInput> confirmUserMfaDeviceInputCaptor;
+//
+//    @Captor
+//    private ArgumentCaptor<UpdateUserInput> updateUserInputCaptor;
+
+    @Test
+    void givenAValidRequest_whenCallCreateMailConfirmationToken_thenReturnMailIdAndUserId() throws Exception {
+        final var aMail = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.EMAIL_CONFIRMATION
+        );
+
+        final var aEmail = aMail.getEmail();
+
+        Mockito.when(createMailTokenUseCase.execute(Mockito.any()))
+                .thenAnswer(call -> new CreateMailTokenOutput(aMail));
+
+        var json = """
+                {
+                    "email": "%s"
+                }
+                """.formatted(aEmail);
+
+        final var aRequest = MockMvcRequestBuilders.post("/v1/mail-tokens/email-confirmation")
+                .with(ApiTest.admin())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json);
+
+        final var aResponse = mvc.perform(aRequest);
+
+        aResponse
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.user_id").value(aMail.getUserId().value().toString()))
+                .andExpect(jsonPath("$.mail_id").value(aMail.getId().value().toString()))
+                .andExpect(jsonPath("$.type").value(aMail.getType().name()));
+
+        Mockito.verify(createMailTokenUseCase, Mockito.times(1)).execute(createMailTokenInputCaptor.capture());
+
+        final var aCapturedInput = createMailTokenInputCaptor.getValue();
+
+        Assertions.assertEquals(aEmail, aCapturedInput.email());
+    }
+
+    @Test
+    void givenAValidRequest_whenCallCreateMailPasswordResetToken_thenReturnMailIdAndUserId() throws Exception {
+        final var aMail = Fixture.Mails.mail(
+                Fixture.Users.email(),
+                IdentifierUtils.generateNewId(),
+                MailType.PASSWORD_RESET
+        );
+
+        final var aEmail = aMail.getEmail();
+
+        Mockito.when(createMailTokenUseCase.execute(Mockito.any()))
+                .thenAnswer(call -> new CreateMailTokenOutput(aMail));
+
+        var json = """
+                {
+                    "email": "%s"
+                }
+                """.formatted(aEmail);
+
+        final var aRequest = MockMvcRequestBuilders.post("/v1/mail-tokens/password-reset")
+                .with(ApiTest.admin())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json);
+
+        final var aResponse = mvc.perform(aRequest);
+
+        aResponse
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.user_id").value(aMail.getUserId().value().toString()))
+                .andExpect(jsonPath("$.mail_id").value(aMail.getId().value().toString()))
+                .andExpect(jsonPath("$.type").value(aMail.getType().name()));
+
+        Mockito.verify(createMailTokenUseCase, Mockito.times(1)).execute(createMailTokenInputCaptor.capture());
+
+        final var aCapturedInput = createMailTokenInputCaptor.getValue();
+
+        Assertions.assertEquals(aEmail, aCapturedInput.email());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/users/UserRepositoryImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/auth/infrastructure/users/UserRepositoryImplTest.java
@@ -162,4 +162,31 @@ class UserRepositoryImplTest {
         Assertions.assertEquals(aUser.getUpdatedAt(), aOutput.getUpdatedAt());
         Assertions.assertTrue(aOutput.getDeletedAt().isEmpty());
     }
+
+    @Test
+    void givenAValidEmail_whenCallFindByEmail_thenReturnUser() {
+        final var aDefaultRole = Fixture.Roles.defaultRole();
+        this.roleJpaEntityRepository.saveAndFlush(RoleJpaEntity.toEntity(aDefaultRole));
+
+        final var aUser = Fixture.Users.randomUser(aDefaultRole.getId());
+
+        this.userJpaEntityRepository.saveAndFlush(UserJpaEntity.toEntity(aUser));
+
+        Assertions.assertEquals(1, this.userJpaEntityRepository.count());
+
+        final var aOutput = this.userRepositoryImpl.findByEmail(aUser.getEmail().value()).get();
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertEquals(aUser.getId().value(), aOutput.getId().value());
+        Assertions.assertEquals(aUser.getCustomerId().value(), aOutput.getCustomerId().value());
+        Assertions.assertEquals(aUser.getName().firstName(), aOutput.getName().firstName());
+        Assertions.assertEquals(aUser.getName().lastName(), aOutput.getName().lastName());
+        Assertions.assertEquals(aUser.getEmail().value(), aOutput.getEmail().value());
+        Assertions.assertEquals(aUser.getPassword().value(), aOutput.getPassword().value());
+        Assertions.assertEquals(aUser.isDeleted(), aOutput.isDeleted());
+        Assertions.assertEquals(aUser.isEmailVerified(), aOutput.isEmailVerified());
+        Assertions.assertEquals(aUser.getCreatedAt(), aOutput.getCreatedAt());
+        Assertions.assertEquals(aUser.getUpdatedAt(), aOutput.getUpdatedAt());
+        Assertions.assertTrue(aOutput.getDeletedAt().isEmpty());
+    }
 }


### PR DESCRIPTION
## Descrição

Foi adicionado o mail token, junto com as rotas mail-confirmation e reset-password, assim criamos o token do email e no futuro podemos criar um evento e publicar para o serviço de email mandar o email

## Tipo de Mudança
Marque com um "x" os tipos de mudanças que se aplicam ao seu PR.

- [ ] Bugfix (correção de um problema)
- [X] Nova funcionalidade (adicionar uma nova funcionalidade)
- [ ] Mudança na funcionalidade existente (melhorias ou mudanças em funcionalidades existentes)
- [ ] Refatoração (mudança na estrutura do código sem alterar a funcionalidade)
- [ ] Documentação (adição ou atualização da documentação)
- [ ] Outra (especificar)

## Checklist
Marque com um "x" as tarefas completadas.

- [X] O código segue o padrão de estilo do projeto.
- [X] A documentação foi atualizada (se aplicável).
- [X] Foram adicionados testes que cobrem estas mudanças.
- [X] Todos os testes existentes foram executados e aprovados.
- [X] A revisão de segurança foi realizada (se aplicável).

## Links Relacionados
Adicione links para issues, cards do Trello, etc., que estejam relacionados a este PR.